### PR TITLE
Add explicit pyqt dependency

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - numba
     - pandas
     - pyarrow
+    - pyqt
     - pyyaml
     - qtpy
     - scikit-image


### PR DESCRIPTION
The napari conda package no longer explicitly pulls in pyqt so we need to do it ourselves.