### PR TITLE
Fix line break issues

### DIFF
--- a/cylinter/modules/selectROIs.py
+++ b/cylinter/modules/selectROIs.py
@@ -153,8 +153,7 @@ def selectROIs(data, self, args):
                         updated_layer_data.append((shape_type, roi))
                     extra_layers[varname][sample] = updated_layer_data
                 elif layer_type[varname] == 'point':
-                    updated_layer_data = layer.data, global_state.artifact_mask,
-                    global_state.artifact_proba
+                    updated_layer_data = layer.data, global_state.artifact_mask, global_state.artifact_proba
                     extra_layers[varname][sample] = updated_layer_data
 
                 f = open(os.path.join(roi_dir, filename), 'wb')
@@ -218,8 +217,7 @@ def selectROIs(data, self, args):
                 elif layer_type[varname] == 'point':
                     if self.autoArtifactDetection:
                         try:
-                            points, global_state.artifact_mask,
-                            global_state.artifact_proba = layer_data[sample]
+                            points, global_state.artifact_mask, global_state.artifact_proba = layer_data[sample]
                             artifact_mask_ = (
                                 global_state.artifact_mask[global_state.binarized_artifact_mask]
                             )


### PR DESCRIPTION
When copying my selectROI module code, some additional line breaks are introduced that cause the current CyLinter program to silently ignore the detected artifact Points layer when saving and reading the data. These are fixed in the latest commit on my masters branch, which I now request to pull into the LSP master branch.